### PR TITLE
Dependency and Swift 3.1 cleanup (chore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Packages
 *.xcodeproj
 *.xcodeproj/xcshareddata/xcbaselines/4724F8141DA88A530003BAC6.xcbaseline
+Package.pins
+

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,6 @@ let package = Package(
     name: "S3SignerAWS",
     targets: [],
     dependencies: [
-        .Package(url: "https://github.com/vapor/crypto.git", majorVersion: 2),
-        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 2)
+        .Package(url: "https://github.com/vapor/crypto.git", majorVersion: 2)
     ]
 )

--- a/Tests/S3SignerAWSTests/S3SignerAWSTests.swift
+++ b/Tests/S3SignerAWSTests/S3SignerAWSTests.swift
@@ -6,13 +6,9 @@
 //
 //
 
+@testable import S3SignerAWS
 import XCTest
 import Foundation
-@testable import S3SignerAWS
-@testable import HMAC
-@testable import Hash
-@testable import Core
-@testable import Essentials
 
 class S3SignerAWSTests: XCTestCase {
     


### PR DESCRIPTION
This PR includes some spring cleaning:
- The dependency on vapor/vapor is removed. The vapor/crypto dependency covers everything that this package uses, so pulling in the mother project is unnecessary exercise for SPM.
- Package.pins is ignored, so dependant projects can safely use this package without the risk of version conflicts in the future.
- The imports in the test source are cleaned up, so the tests compile and run now in Xcode.